### PR TITLE
handle named nulls in vlog conversion

### DIFF
--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/reasoner/implementation/ModelToVLogConverter.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/reasoner/implementation/ModelToVLogConverter.java
@@ -23,6 +23,7 @@ package org.semanticweb.rulewerk.core.reasoner.implementation;
 import java.util.Collection;
 import java.util.List;
 
+import org.semanticweb.rulewerk.core.exceptions.RulewerkRuntimeException;
 import org.semanticweb.rulewerk.core.model.api.Conjunction;
 import org.semanticweb.rulewerk.core.model.api.Constant;
 import org.semanticweb.rulewerk.core.model.api.Fact;
@@ -86,8 +87,8 @@ final class ModelToVLogConverter {
 			} else if (term instanceof NamedNull) {
 				vLogFactTuple[i] = TermToVLogConverter.getVLogNameForNamedNull((NamedNull) term);
 			} else {
-				throw new RuntimeException("Terms in facts must be constants of named nulls. Encountered " + term
-						+ " of type " + term.getType() + ".");
+				throw new RulewerkRuntimeException("Terms in facts must be constants or named nulls. Encountered "
+						+ term + " of type " + term.getType() + ".");
 			}
 			i++;
 		}

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/reasoner/implementation/ModelToVLogConverter.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/reasoner/implementation/ModelToVLogConverter.java
@@ -27,6 +27,7 @@ import org.semanticweb.rulewerk.core.model.api.Conjunction;
 import org.semanticweb.rulewerk.core.model.api.Constant;
 import org.semanticweb.rulewerk.core.model.api.Fact;
 import org.semanticweb.rulewerk.core.model.api.Literal;
+import org.semanticweb.rulewerk.core.model.api.NamedNull;
 import org.semanticweb.rulewerk.core.model.api.Predicate;
 import org.semanticweb.rulewerk.core.model.api.Rule;
 import org.semanticweb.rulewerk.core.model.api.Term;
@@ -80,7 +81,14 @@ final class ModelToVLogConverter {
 		int i = 0;
 		for (final Term term : terms) {
 			// No checks for type of term -- only constants allowed in facts!
-			vLogFactTuple[i] = TermToVLogConverter.getVLogNameForConstant((Constant)term);
+			if (term instanceof Constant) {
+				vLogFactTuple[i] = TermToVLogConverter.getVLogNameForConstant((Constant) term);
+			} else if (term instanceof NamedNull) {
+				vLogFactTuple[i] = TermToVLogConverter.getVLogNameForNamedNull((NamedNull) term);
+			} else {
+				throw new RuntimeException("Terms in facts must be constants of named nulls. Encountered " + term
+						+ " of type " + term.getType() + ".");
+			}
 			i++;
 		}
 		return vLogFactTuple;

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/reasoner/implementation/Skolemization.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/reasoner/implementation/Skolemization.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.UUID;
 
+import org.semanticweb.rulewerk.core.exceptions.RulewerkRuntimeException;
 import org.semanticweb.rulewerk.core.model.api.NamedNull;
 import org.semanticweb.rulewerk.core.model.implementation.RenamedNamedNull;
 
@@ -47,15 +48,17 @@ public class Skolemization {
 	 * a {@link RenamedNamedNull} instance with the same name when
 	 * called on the same instance.
 	 *
-	 * @throws IOException when ByteArrayOutputStream throws.
 	 * @return a {@link RenamedNamedNull} instance with a new name
 	 *         that is specific to this instance and {@code name}.
 	 */
-	public RenamedNamedNull skolemizeNamedNull(String name) throws IOException {
+	public RenamedNamedNull skolemizeNamedNull(String name) {
 		ByteArrayOutputStream stream = new ByteArrayOutputStream();
-		stream.write(namedNullNamespace);
-		stream.write(name.getBytes());
-
-		return new RenamedNamedNull(UUID.nameUUIDFromBytes(stream.toByteArray()));
+		try {
+			stream.write(namedNullNamespace);
+			stream.write(name.getBytes());
+			return new RenamedNamedNull(UUID.nameUUIDFromBytes(stream.toByteArray()));
+		} catch (IOException e) {
+			throw new RulewerkRuntimeException(e.getMessage(), e);
+		}
 	}
 }

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/reasoner/implementation/TermToVLogConverter.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/reasoner/implementation/TermToVLogConverter.java
@@ -85,9 +85,9 @@ class TermToVLogConverter implements TermVisitor<karmaresearch.vlog.Term> {
 			return constant.getName();
 		}
 	}
-	
+
 	/**
-	 * Converts the given named null to the name of a constant in VLog.
+	 * Converts the given named null to the name of a (skolem) constant in VLog.
 	 *
 	 * @param named null
 	 * @return VLog constant string
@@ -132,8 +132,8 @@ class TermToVLogConverter implements TermVisitor<karmaresearch.vlog.Term> {
 	}
 
 	/**
-	 * Transforms a named null to a {@link karmaresearch.vlog.Term} with the same name
-	 * and type {@link karmaresearch.vlog.Term.TermType#BLANK}.
+	 * Transforms a named null to a {@link karmaresearch.vlog.Term} with the same
+	 * name and type {@link karmaresearch.vlog.Term.TermType#BLANK}.
 	 */
 	@Override
 	public karmaresearch.vlog.Term visit(NamedNull term) {

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/reasoner/implementation/TermToVLogConverter.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/reasoner/implementation/TermToVLogConverter.java
@@ -29,6 +29,7 @@ import org.semanticweb.rulewerk.core.model.api.ExistentialVariable;
 import org.semanticweb.rulewerk.core.model.api.LanguageStringConstant;
 import org.semanticweb.rulewerk.core.model.api.TermVisitor;
 import org.semanticweb.rulewerk.core.model.api.UniversalVariable;
+import org.semanticweb.rulewerk.core.model.implementation.RenamedNamedNull;
 
 /**
  * A visitor that converts {@link Term}s of different types to corresponding
@@ -38,6 +39,8 @@ import org.semanticweb.rulewerk.core.model.api.UniversalVariable;
  *
  */
 class TermToVLogConverter implements TermVisitor<karmaresearch.vlog.Term> {
+
+	static final Skolemization skolemization = new Skolemization();
 
 	/**
 	 * Transforms an abstract constant to a {@link karmaresearch.vlog.Term} with the
@@ -89,14 +92,15 @@ class TermToVLogConverter implements TermVisitor<karmaresearch.vlog.Term> {
 	/**
 	 * Converts the given named null to the name of a (skolem) constant in VLog.
 	 *
-	 * @fixme This skolemisation approach might lead to constants that clash with
-	 *        existing constant names.
-	 *
 	 * @param named null
 	 * @return VLog constant string
 	 */
 	public static String getVLogNameForNamedNull(NamedNull namedNull) {
-		return "skolem__" + namedNull.getName();
+		if (namedNull instanceof RenamedNamedNull) {
+			return namedNull.getName();
+		} else {
+			return skolemization.skolemizeNamedNull(namedNull.getName()).getName();
+		}
 	}
 
 	/**

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/reasoner/implementation/TermToVLogConverter.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/reasoner/implementation/TermToVLogConverter.java
@@ -85,6 +85,16 @@ class TermToVLogConverter implements TermVisitor<karmaresearch.vlog.Term> {
 			return constant.getName();
 		}
 	}
+	
+	/**
+	 * Converts the given named null to the name of a constant in VLog.
+	 *
+	 * @param named nul
+	 * @return VLog constant string
+	 */
+	public static String getVLogNameForNamedNull(NamedNull namedNull) {
+		return "skolem__" + namedNull.getName();
+	}
 
 	/**
 	 * Converts the string representation of a constant in Rulewerk directly to the

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/reasoner/implementation/TermToVLogConverter.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/reasoner/implementation/TermToVLogConverter.java
@@ -89,7 +89,7 @@ class TermToVLogConverter implements TermVisitor<karmaresearch.vlog.Term> {
 	/**
 	 * Converts the given named null to the name of a constant in VLog.
 	 *
-	 * @param named nul
+	 * @param named null
 	 * @return VLog constant string
 	 */
 	public static String getVLogNameForNamedNull(NamedNull namedNull) {

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/reasoner/implementation/TermToVLogConverter.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/reasoner/implementation/TermToVLogConverter.java
@@ -89,6 +89,9 @@ class TermToVLogConverter implements TermVisitor<karmaresearch.vlog.Term> {
 	/**
 	 * Converts the given named null to the name of a (skolem) constant in VLog.
 	 *
+	 * @fixme This skolemisation approach might lead to constants that clash with
+	 *        existing constant names.
+	 *
 	 * @param named null
 	 * @return VLog constant string
 	 */

--- a/rulewerk-core/src/test/java/org/semanticweb/rulewerk/core/reasoner/implementation/ModelToVLogConverterTest.java
+++ b/rulewerk-core/src/test/java/org/semanticweb/rulewerk/core/reasoner/implementation/ModelToVLogConverterTest.java
@@ -33,14 +33,17 @@ import java.util.UUID;
 
 import org.junit.Test;
 import org.semanticweb.rulewerk.core.model.api.NamedNull;
+import org.semanticweb.rulewerk.core.exceptions.RulewerkRuntimeException;
 import org.semanticweb.rulewerk.core.model.api.Constant;
 import org.semanticweb.rulewerk.core.model.api.Fact;
 import org.semanticweb.rulewerk.core.model.api.PositiveLiteral;
 import org.semanticweb.rulewerk.core.model.api.Predicate;
 import org.semanticweb.rulewerk.core.model.api.Rule;
+import org.semanticweb.rulewerk.core.model.api.StatementVisitor;
 import org.semanticweb.rulewerk.core.model.api.Term;
 import org.semanticweb.rulewerk.core.model.api.Variable;
 import org.semanticweb.rulewerk.core.model.implementation.NamedNullImpl;
+import org.semanticweb.rulewerk.core.model.implementation.PositiveLiteralImpl;
 import org.semanticweb.rulewerk.core.model.implementation.RenamedNamedNull;
 import org.semanticweb.rulewerk.core.model.implementation.Expressions;
 import org.semanticweb.rulewerk.core.reasoner.RuleRewriteStrategy;
@@ -127,9 +130,9 @@ public class ModelToVLogConverterTest {
 		final String vLogSkolemConstant = TermToVLogConverter.getVLogNameForNamedNull(blank);
 
 		assertNotEquals("blank", vLogSkolemConstant);
-		assertEquals(36,vLogSkolemConstant.length()); // length of a UUID
+		assertEquals(36, vLogSkolemConstant.length()); // length of a UUID
 	}
-	
+
 	@Test
 	public void testToVLogTermBlankRenamedSkolemization() {
 		final UUID uuid = UUID.randomUUID();
@@ -185,6 +188,41 @@ public class ModelToVLogConverterTest {
 
 		final String[][] expectedTuples = { { "1" }, { "2", "3" } };
 		assertArrayEquals(expectedTuples, vLogTuples);
+	}
+
+	@Test
+	public void testToVLogFactTupleNulls() {
+		final UUID uuid = UUID.randomUUID();
+		final NamedNull n = new RenamedNamedNull(uuid);
+		final Fact atom1 = Expressions.makeFact("p1", Arrays.asList(n));
+
+		final String[] expectedTuple = { uuid.toString() };
+
+		final String[] actualTuple = ModelToVLogConverter.toVLogFactTuple(atom1);
+
+		assertArrayEquals(expectedTuple, actualTuple);
+	}
+
+	@Test(expected = RulewerkRuntimeException.class)
+	public void testToVLogFactTupleUnsupported() {
+		// We need a fact that accepts exception-causing terms in the first place:
+		class NonValidatingFact extends PositiveLiteralImpl implements Fact {
+
+			public NonValidatingFact(Predicate predicate, List<Term> terms) {
+				super(predicate, terms);
+			}
+
+			@Override
+			public <T> T accept(StatementVisitor<T> statementVisitor) {
+				return statementVisitor.visit(this);
+			}
+
+		}
+
+		final Variable x = Expressions.makeUniversalVariable("X");
+		final Fact atom1 = new NonValidatingFact(Expressions.makePredicate("p1", 1), Arrays.asList(x));
+
+		ModelToVLogConverter.toVLogFactTuple(atom1);
 	}
 
 	@Test

--- a/rulewerk-core/src/test/java/org/semanticweb/rulewerk/core/reasoner/implementation/ModelToVLogConverterTest.java
+++ b/rulewerk-core/src/test/java/org/semanticweb/rulewerk/core/reasoner/implementation/ModelToVLogConverterTest.java
@@ -118,6 +118,15 @@ public class ModelToVLogConverterTest {
 	}
 
 	@Test
+	public void testToVLogTermBlankSkolemization() {
+		final NamedNull blank = new NamedNullImpl("blank");
+
+		final String vLogSkolemConstant = TermToVLogConverter.getVLogNameForNamedNull(blank);
+
+		assertEquals("skolem__blank", vLogSkolemConstant);
+	}
+
+	@Test
 	public void testToVLogTermArray() {
 		final Variable vx = Expressions.makeUniversalVariable("x");
 		final Variable vxToo = Expressions.makeUniversalVariable("x");

--- a/rulewerk-core/src/test/java/org/semanticweb/rulewerk/core/reasoner/implementation/ModelToVLogConverterTest.java
+++ b/rulewerk-core/src/test/java/org/semanticweb/rulewerk/core/reasoner/implementation/ModelToVLogConverterTest.java
@@ -22,12 +22,14 @@ package org.semanticweb.rulewerk.core.reasoner.implementation;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.Test;
 import org.semanticweb.rulewerk.core.model.api.NamedNull;
@@ -39,6 +41,7 @@ import org.semanticweb.rulewerk.core.model.api.Rule;
 import org.semanticweb.rulewerk.core.model.api.Term;
 import org.semanticweb.rulewerk.core.model.api.Variable;
 import org.semanticweb.rulewerk.core.model.implementation.NamedNullImpl;
+import org.semanticweb.rulewerk.core.model.implementation.RenamedNamedNull;
 import org.semanticweb.rulewerk.core.model.implementation.Expressions;
 import org.semanticweb.rulewerk.core.reasoner.RuleRewriteStrategy;
 
@@ -123,7 +126,18 @@ public class ModelToVLogConverterTest {
 
 		final String vLogSkolemConstant = TermToVLogConverter.getVLogNameForNamedNull(blank);
 
-		assertEquals("skolem__blank", vLogSkolemConstant);
+		assertNotEquals("blank", vLogSkolemConstant);
+		assertEquals(36,vLogSkolemConstant.length()); // length of a UUID
+	}
+	
+	@Test
+	public void testToVLogTermBlankRenamedSkolemization() {
+		final UUID uuid = UUID.randomUUID();
+		final NamedNull blank = new RenamedNamedNull(uuid);
+
+		final String vLogSkolemConstant = TermToVLogConverter.getVLogNameForNamedNull(blank);
+
+		assertEquals(uuid.toString(), vLogSkolemConstant);
 	}
 
 	@Test

--- a/rulewerk-core/src/test/java/org/semanticweb/rulewerk/core/reasoner/implementation/VLogReasonerWriteInferencesTest.java
+++ b/rulewerk-core/src/test/java/org/semanticweb/rulewerk/core/reasoner/implementation/VLogReasonerWriteInferencesTest.java
@@ -9,14 +9,11 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.internal.util.collections.Sets;
 import org.semanticweb.rulewerk.core.exceptions.PrefixDeclarationException;
 import org.semanticweb.rulewerk.core.model.api.AbstractConstant;
 import org.semanticweb.rulewerk.core.model.api.Conjunction;

--- a/rulewerk-owlapi/src/main/java/org/semanticweb/rulewerk/owlapi/ClassToRuleBodyConverter.java
+++ b/rulewerk-owlapi/src/main/java/org/semanticweb/rulewerk/owlapi/ClassToRuleBodyConverter.java
@@ -117,7 +117,7 @@ public class ClassToRuleBodyConverter extends AbstractClassToRuleConverter imple
 
 	@Override
 	public void visit(final OWLObjectHasValue ce) {
-		final Term term = OwlToRulesConversionHelper.getIndividualTerm(ce.getFiller());
+		final Term term = OwlToRulesConversionHelper.getIndividualTerm(ce.getFiller(), parent.skolemization);
 		OwlToRulesConversionHelper.addConjunctForPropertyExpression(ce.getProperty(), this.mainTerm, term, this.body);
 	}
 

--- a/rulewerk-owlapi/src/main/java/org/semanticweb/rulewerk/owlapi/ClassToRuleHeadConverter.java
+++ b/rulewerk-owlapi/src/main/java/org/semanticweb/rulewerk/owlapi/ClassToRuleHeadConverter.java
@@ -112,7 +112,7 @@ public class ClassToRuleHeadConverter extends AbstractClassToRuleConverter imple
 
 	@Override
 	public void visit(final OWLObjectHasValue ce) {
-		final Term term = OwlToRulesConversionHelper.getIndividualTerm(ce.getFiller());
+		final Term term = OwlToRulesConversionHelper.getIndividualTerm(ce.getFiller(), parent.skolemization);
 		OwlToRulesConversionHelper.addConjunctForPropertyExpression(ce.getProperty(), this.mainTerm, term, this.head);
 	}
 

--- a/rulewerk-owlapi/src/main/java/org/semanticweb/rulewerk/owlapi/OwlToRulesConversionHelper.java
+++ b/rulewerk-owlapi/src/main/java/org/semanticweb/rulewerk/owlapi/OwlToRulesConversionHelper.java
@@ -40,9 +40,9 @@ import org.semanticweb.rulewerk.core.model.api.Predicate;
 import org.semanticweb.rulewerk.core.model.api.Term;
 import org.semanticweb.rulewerk.core.model.implementation.AbstractConstantImpl;
 import org.semanticweb.rulewerk.core.model.implementation.FactImpl;
-import org.semanticweb.rulewerk.core.model.implementation.NamedNullImpl;
 import org.semanticweb.rulewerk.core.model.implementation.PositiveLiteralImpl;
 import org.semanticweb.rulewerk.core.model.implementation.PredicateImpl;
+import org.semanticweb.rulewerk.core.reasoner.implementation.Skolemization;
 import org.semanticweb.rulewerk.owlapi.AbstractClassToRuleConverter.SimpleConjunction;
 
 /**
@@ -60,11 +60,11 @@ public class OwlToRulesConversionHelper {
 	 * @param owlIndividual the individual to get a term for
 	 * @return a suitable term
 	 */
-	public static Term getIndividualTerm(final OWLIndividual owlIndividual) {
+	public static Term getIndividualTerm(final OWLIndividual owlIndividual, Skolemization skolemization) {
 		if (owlIndividual instanceof OWLNamedIndividual) {
 			return new AbstractConstantImpl(((OWLNamedIndividual) owlIndividual).getIRI().toString());
 		} else if (owlIndividual instanceof OWLAnonymousIndividual) {
-			return new NamedNullImpl(((OWLAnonymousIndividual) owlIndividual).getID().toString());
+			return skolemization.skolemizeNamedNull(((OWLAnonymousIndividual) owlIndividual).getID().toString());
 		} else {
 			throw new OwlFeatureNotSupportedException(
 					"Could not convert OWL individual '" + owlIndividual.toString() + "' to a term.");

--- a/rulewerk-owlapi/src/main/java/org/semanticweb/rulewerk/owlapi/OwlToRulesConverter.java
+++ b/rulewerk-owlapi/src/main/java/org/semanticweb/rulewerk/owlapi/OwlToRulesConverter.java
@@ -40,10 +40,10 @@ public class OwlToRulesConverter {
 	 * Converts the given OWL ontology to rules and facts, and adds the result to
 	 * the internal buffer of rules and facts for later retrieval.
 	 *
-	 * @param owlOntology
-	 *            the ontology
+	 * @param owlOntology the ontology
 	 */
 	public void addOntology(final OWLOntology owlOntology) {
+		this.owlAxiomToRulesConverter.startNewBlankNodeContext();
 		owlOntology.axioms().forEach(owlAxiom -> owlAxiom.accept(this.owlAxiomToRulesConverter));
 	}
 

--- a/rulewerk-owlapi/src/test/java/org/semanticweb/rulewerk/owlapi/OwlAxiomToRulesConverterTest.java
+++ b/rulewerk-owlapi/src/test/java/org/semanticweb/rulewerk/owlapi/OwlAxiomToRulesConverterTest.java
@@ -634,16 +634,16 @@ public class OwlAxiomToRulesConverterTest {
 
 		assertEquals(Collections.singleton(rule), converter.rules);
 	}
-	
+
 	/*
 	 * A \sqsubseteq <1 .R
 	 */
 	@Test(expected = OwlFeatureNotSupportedException.class)
 	public void testSubClassOfMaxCardinality() {
-		
+
 		OWLClassExpression maxCard = df.getOWLObjectMaxCardinality(1, pR);
-		OWLSubClassOfAxiom axiom = df.getOWLSubClassOfAxiom(cA, maxCard );
-		
+		OWLSubClassOfAxiom axiom = df.getOWLSubClassOfAxiom(cA, maxCard);
+
 		final OwlAxiomToRulesConverter converter = new OwlAxiomToRulesConverter();
 		axiom.accept(converter);
 	}
@@ -695,7 +695,7 @@ public class OwlAxiomToRulesConverterTest {
 		final OwlAxiomToRulesConverter converter = new OwlAxiomToRulesConverter();
 		axiom.accept(converter);
 	}
-	
+
 	/*
 	 * (B \sqcap {a,b}) \sqsubseteq A
 	 */
@@ -710,9 +710,8 @@ public class OwlAxiomToRulesConverterTest {
 		axiom.accept(converter);
 	}
 
-	
 	/*
-	 * A \sqsubseteq (B \sqcap {a,b}) 
+	 * A \sqsubseteq (B \sqcap {a,b})
 	 */
 	@Test(expected = OwlFeatureNotSupportedException.class)
 	public void testClassSubClassOfNominalsInConjunctionRight() {
@@ -723,7 +722,6 @@ public class OwlAxiomToRulesConverterTest {
 		final OwlAxiomToRulesConverter converter = new OwlAxiomToRulesConverter();
 		axiom.accept(converter);
 	}
-
 
 	/*
 	 * A \sqsubseteq {a}

--- a/rulewerk-owlapi/src/test/java/org/semanticweb/rulewerk/owlapi/OwlToRulesConverterTest.java
+++ b/rulewerk-owlapi/src/test/java/org/semanticweb/rulewerk/owlapi/OwlToRulesConverterTest.java
@@ -1,0 +1,48 @@
+package org.semanticweb.rulewerk.owlapi;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAnonymousIndividual;
+import org.semanticweb.owlapi.model.OWLAxiom;
+import org.semanticweb.owlapi.model.OWLClass;
+import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.semanticweb.owlapi.model.OWLIndividual;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+
+public class OwlToRulesConverterTest {
+	
+	static OWLDataFactory df = OWLManager.getOWLDataFactory();
+	
+	public static IRI getIri(final String localName) {
+		return IRI.create("http://example.org/" + localName);
+	}
+
+	public static OWLClass getOwlClass(final String localName) {
+		return df.getOWLClass(getIri(localName));
+	}
+	
+	static final OWLClass cC = getOwlClass("C");
+	static final OWLIndividual inda = df.getOWLNamedIndividual(getIri("a"));
+
+	@Test
+	public void testLoadOntologies() throws OWLOntologyCreationException {
+		final OWLAnonymousIndividual bnode = df.getOWLAnonymousIndividual("abc");
+		final OWLAxiom Cn = df.getOWLClassAssertionAxiom(cC, bnode);
+		final OWLAxiom Ca = df.getOWLClassAssertionAxiom(cC, inda);
+		
+		final OWLOntology ontology =  OWLManager.createOWLOntologyManager().createOntology(Arrays.asList(Cn,Ca));
+
+		final OwlToRulesConverter converter = new OwlToRulesConverter();
+		converter.addOntology(ontology);
+		converter.addOntology(ontology);
+
+		assertEquals(3, converter.getFacts().size());
+	}
+
+}

--- a/rulewerk-parser/src/main/java/org/semanticweb/rulewerk/parser/javacc/JavaCCParserBase.java
+++ b/rulewerk-parser/src/main/java/org/semanticweb/rulewerk/parser/javacc/JavaCCParserBase.java
@@ -162,11 +162,7 @@ public class JavaCCParserBase {
 	}
 
 	NamedNull createNamedNull(String lexicalForm) throws ParseException {
-		try {
-			return this.skolemization.skolemizeNamedNull(lexicalForm);
-		} catch (IOException e) {
-			throw makeParseExceptionWithCause("Failed to generate a unique name for named null", e);
-		}
+		return this.skolemization.skolemizeNamedNull(lexicalForm);
 	}
 
 	void addStatement(Statement statement) {

--- a/rulewerk-parser/src/main/java/org/semanticweb/rulewerk/parser/javacc/JavaCCParserBase.java
+++ b/rulewerk-parser/src/main/java/org/semanticweb/rulewerk/parser/javacc/JavaCCParserBase.java
@@ -20,7 +20,6 @@ package org.semanticweb.rulewerk.parser.javacc;
  * #L%
  */
 
-import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 


### PR DESCRIPTION
This code introduces a simple skolemisation of named nulls when encountered during the conversion of Rulewerk facts to VLog data. VLog at this point works with strings and has no notion of null, so we have to skolemise. The approach is cheap and may still lead to clashes with previously skolemised nulls if their IDs are not properly UUIDed.