### PR TITLE
Disjunctions in Rules

### DIFF
--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/Conjunction.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/Conjunction.java
@@ -9,9 +9,9 @@ package org.semanticweb.rulewerk.core.model.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,22 +21,29 @@ package org.semanticweb.rulewerk.core.model.api;
  */
 
 import java.util.List;
+import java.util.Arrays;
 
 /**
  * Interface for representing conjunctions of {@link Literal}s, i.e., lists of
  * (negated or positive) atomic formulas that are connected with logical AND.
  * Conjunctions may have free variables, since they contain no quantifiers.
- * 
+ *
  * @author Markus Krötzsch
+ * @author Lukas Gerlach
  *
  */
-public interface Conjunction<T extends Literal> extends Iterable<T>, SyntaxObject {
+public interface Conjunction<T extends Literal> extends Disjunction<Conjunction<T>>, Iterable<T> {
 
 	/**
 	 * Returns the list of literals that are part of this conjunction.
-	 * 
+	 *
 	 * @return list of literals
 	 */
 	List<T> getLiterals();
+
+	@Override
+	default List<Conjunction<T>> getConjunctions() {
+		return Arrays.asList(this);
+	}
 
 }

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/Disjunction.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/Disjunction.java
@@ -23,12 +23,11 @@ package org.semanticweb.rulewerk.core.model.api;
 import java.util.List;
 
 /**
- * Interface for representing disjunctions of {@link Conjunctions}s.
+ * Interface for representing disjunctions of {@link Conjunction}s.
  *
  * @author Lukas Gerlach
  *
  */
-// TODO: extend iterable over conjunctions too? (conflicts with Conjunction because this extends Iterable for Literal)
 public interface Disjunction<T extends Conjunction<?>> extends SyntaxObject {
 
 	/**

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/Disjunction.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/Disjunction.java
@@ -28,7 +28,8 @@ import java.util.List;
  * @author Lukas Gerlach
  *
  */
-public interface Disjunction<T extends Conjunction<?>> extends Iterable<T>, SyntaxObject {
+// TODO: extend iterable over conjunctions too? (conflicts with Conjunction because this extends Iterable for Literal)
+public interface Disjunction<T extends Conjunction<?>> extends SyntaxObject {
 
 	/**
 	 * Returns the list of conjunctions that are part of this disjunction.

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/Disjunction.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/Disjunction.java
@@ -20,31 +20,21 @@ package org.semanticweb.rulewerk.core.model.api;
  * #L%
  */
 
+import java.util.List;
+
 /**
- * Interface for classes representing a rule. This implementation assumes that
- * rules are defined by their head and body literals, without explicitly
- * specifying quantifiers. All variables in the body are considered universally
- * quantified; all variables in the head that do not occur in the body are
- * considered existentially quantified.
+ * Interface for representing disjunctions of {@link Conjunctions}s.
  *
- * @author Markus Krötzsch
  * @author Lukas Gerlach
  *
  */
-public interface Rule extends SyntaxObject, Statement {
+public interface Disjunction<T extends Conjunction<?>> extends Iterable<T>, SyntaxObject {
 
 	/**
-	 * Returns the disjunction of conjunctions of head literals (the consequence of the rule).
+	 * Returns the list of conjunctions that are part of this disjunction.
 	 *
-	 * @return conjunction of literals
+	 * @return list of conjunctions
 	 */
-	Disjunction<Conjunction<PositiveLiteral>> getHead();
-
-	/**
-	 * Returns the conjunction of body literals (the premise of the rule).
-	 *
-	 * @return conjunction of literals
-	 */
-	Conjunction<Literal> getBody();
+	List<T> getConjunctions();
 
 }

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/Literal.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/Literal.java
@@ -35,8 +35,16 @@ import java.util.Iterator;
  * @author Lukas Gerlach
  */
 
-// TODO: this is not ideal since PositiveLiteral now also extends Conjunction<Literal>
+// this would also be possible (including other changes)
+// but it is not ideal since PositiveLiteral now also extends Conjunction<Literal>
 // while it should really extend Conjunction<PositiveLiteral> (but maybe this is not too much of an issue...)
+//
+// public interface Literal extends Conjunction<Literal> {
+
+// this produces a so called RawType when used without type argument, which seems to be generally considered
+// bad practice because some type checking is not done for such types
+// maybe this would not be an issue for us...
+// what we actually would need is a self referential type that we can pass to Conjunction...
 public interface Literal<T extends Literal> extends Conjunction<T> {
 
 	boolean isNegated();
@@ -55,11 +63,6 @@ public interface Literal<T extends Literal> extends Conjunction<T> {
 	 *         {@link Predicate} arity.
 	 */
 	List<Term> getArguments();
-
-	// @Override
-	// default List<T> getLiterals() {
-	// 	return Arrays.asList(this);
-	// }
 
 	@Override
 	default Iterator<T> iterator() {

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/Literal.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/Literal.java
@@ -9,9 +9,9 @@ package org.semanticweb.rulewerk.core.model.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +21,8 @@ package org.semanticweb.rulewerk.core.model.api;
  */
 
 import java.util.List;
+import java.util.Arrays;
+import java.util.Iterator;
 
 /**
  * Interface for literals. A positive literal is simply an atomic formula, i.e.,
@@ -30,14 +32,18 @@ import java.util.List;
  *
  * @author david.carral@tu-dresden.de
  * @author Irina Dragoste
+ * @author Lukas Gerlach
  */
-public interface Literal extends SyntaxObject {
+
+// TODO: this is not ideal since PositiveLiteral now also extends Conjunction<Literal>
+// while it should really extend Conjunction<PositiveLiteral> (but maybe this is not too much of an issue...)
+public interface Literal<T extends Literal> extends Conjunction<T> {
 
 	boolean isNegated();
 
 	/**
 	 * The literal predicate.
-	 * 
+	 *
 	 * @return the literal predicate.
 	 */
 	Predicate getPredicate();
@@ -49,5 +55,15 @@ public interface Literal extends SyntaxObject {
 	 *         {@link Predicate} arity.
 	 */
 	List<Term> getArguments();
+
+	// @Override
+	// default List<T> getLiterals() {
+	// 	return Arrays.asList(this);
+	// }
+
+	@Override
+	default Iterator<T> iterator() {
+		return getLiterals().iterator();
+	}
 
 }

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/NegativeLiteral.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/NegativeLiteral.java
@@ -9,9 +9,9 @@ package org.semanticweb.rulewerk.core.model.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,7 @@ package org.semanticweb.rulewerk.core.model.api;
  * #L%
  */
 
-public interface NegativeLiteral extends Literal {
+public interface NegativeLiteral extends Literal<NegativeLiteral> {
 
 	@Override
 	default boolean isNegated() {

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/NegativeLiteral.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/NegativeLiteral.java
@@ -20,6 +20,9 @@ package org.semanticweb.rulewerk.core.model.api;
  * #L%
  */
 
+import java.util.List;
+import java.util.Arrays;
+
 public interface NegativeLiteral extends Literal<NegativeLiteral> {
 
 	@Override
@@ -27,4 +30,8 @@ public interface NegativeLiteral extends Literal<NegativeLiteral> {
 		return true;
 	}
 
+	@Override
+	default List<NegativeLiteral> getLiterals() {
+		return Arrays.asList(this);
+	}
 }

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/PositiveLiteral.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/PositiveLiteral.java
@@ -9,9 +9,9 @@ package org.semanticweb.rulewerk.core.model.api;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,7 @@ package org.semanticweb.rulewerk.core.model.api;
  * #L%
  */
 
-public interface PositiveLiteral extends Literal {
+public interface PositiveLiteral extends Literal<PositiveLiteral> {
 
 	@Override
 	default boolean isNegated() {

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/PositiveLiteral.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/PositiveLiteral.java
@@ -20,10 +20,18 @@ package org.semanticweb.rulewerk.core.model.api;
  * #L%
  */
 
+import java.util.List;
+import java.util.Arrays;
+
 public interface PositiveLiteral extends Literal<PositiveLiteral> {
 
 	@Override
 	default boolean isNegated() {
 		return false;
+	}
+
+	@Override
+	default List<PositiveLiteral> getLiterals() {
+		return Arrays.asList(this);
 	}
 }

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/Rule.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/Rule.java
@@ -36,14 +36,14 @@ public interface Rule extends SyntaxObject, Statement {
 	/**
 	 * Returns the disjunction of conjunctions of head literals (the consequence of the rule).
 	 *
-	 * @return conjunction of literals
+	 * @return disjunction of conjunctions of positive literals
 	 */
 	Disjunction<Conjunction<PositiveLiteral>> getHead();
 
 	/**
-	 * Returns the conjunction of body literals (the premise of the rule).
+	 * Returns the disjunction of conjunctions of body literals (the premise of the rule).
 	 *
-	 * @return conjunction of literals
+	 * @return disjunction of conjunctions of literals
 	 */
 	Disjunction<Conjunction<Literal>> getBody();
 

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/Rule.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/api/Rule.java
@@ -45,6 +45,6 @@ public interface Rule extends SyntaxObject, Statement {
 	 *
 	 * @return conjunction of literals
 	 */
-	Conjunction<Literal> getBody();
+	Disjunction<Conjunction<Literal>> getBody();
 
 }

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/AbstractLiteralImpl.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/AbstractLiteralImpl.java
@@ -9,9 +9,9 @@ package org.semanticweb.rulewerk.core.model.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.Validate;
+import org.semanticweb.rulewerk.core.model.api.Disjunction;
 import org.semanticweb.rulewerk.core.model.api.Literal;
 import org.semanticweb.rulewerk.core.model.api.Predicate;
 import org.semanticweb.rulewerk.core.model.api.Term;
@@ -38,8 +39,9 @@ import org.semanticweb.rulewerk.core.model.api.Term;
  *
  * @author david.carral@tu-dresden.de
  * @author Markus Krötzsch
+ * @author Lukas Gerlach
  */
-public abstract class AbstractLiteralImpl implements Literal {
+public abstract class AbstractLiteralImpl<T extends Literal> implements Literal<T> {
 
 	private final Predicate predicate;
 	private final List<Term> terms;
@@ -82,8 +84,11 @@ public abstract class AbstractLiteralImpl implements Literal {
 		if (obj == null) {
 			return false;
 		}
-		if (!(obj instanceof Literal)) {
+		if (!(obj instanceof Disjunction<?>)) {
 			return false;
+		}
+		if (!(obj instanceof Literal)) {
+			return obj.equals(this);
 		}
 		final Literal other = (Literal) obj;
 

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/ConjunctionImpl.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/ConjunctionImpl.java
@@ -9,9 +9,9 @@ package org.semanticweb.rulewerk.core.model.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,12 +27,13 @@ import java.util.stream.Stream;
 
 import org.apache.commons.lang3.Validate;
 import org.semanticweb.rulewerk.core.model.api.Conjunction;
+import org.semanticweb.rulewerk.core.model.api.Disjunction;
 import org.semanticweb.rulewerk.core.model.api.Literal;
 import org.semanticweb.rulewerk.core.model.api.Term;
 
 /**
  * Simple implementation of {@link Conjunction}.
- * 
+ *
  * @author Markus Krötzsch
  */
 public class ConjunctionImpl<T extends Literal> implements Conjunction<T> {
@@ -41,7 +42,7 @@ public class ConjunctionImpl<T extends Literal> implements Conjunction<T> {
 
 	/**
 	 * Constructor.
-	 * 
+	 *
 	 * @param literals a non-null list of literals, that cannot contain null
 	 *                 elements.
 	 */
@@ -62,7 +63,9 @@ public class ConjunctionImpl<T extends Literal> implements Conjunction<T> {
 
 	@Override
 	public int hashCode() {
-		return this.literals.hashCode();
+		return this.literals.size() == 1
+			? this.literals.get(0).hashCode()
+			: this.literals.hashCode();
 	}
 
 	@Override
@@ -73,8 +76,14 @@ public class ConjunctionImpl<T extends Literal> implements Conjunction<T> {
 		if (obj == null) {
 			return false;
 		}
-		if (!(obj instanceof Conjunction<?>)) {
+		if (!(obj instanceof Disjunction<?>)) {
 			return false;
+		}
+		if (!(obj instanceof Conjunction<?>)) {
+			// final Disjunction<Conjunction<?>> disjunction = (Disjunction<Conjunction<?>>) obj;
+			// final List<Conjunction<?>> disjuncts = disjunction.getConjunctions();
+			// return disjuncts.size() == 1 && this.equals(disjuncts.get(0));
+			return obj.equals(this);
 		}
 		final Conjunction<?> other = (Conjunction<?>) obj;
 		return this.literals.equals(other.getLiterals());

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/ConjunctionImpl.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/ConjunctionImpl.java
@@ -80,9 +80,6 @@ public class ConjunctionImpl<T extends Literal> implements Conjunction<T> {
 			return false;
 		}
 		if (!(obj instanceof Conjunction<?>)) {
-			// final Disjunction<Conjunction<?>> disjunction = (Disjunction<Conjunction<?>>) obj;
-			// final List<Conjunction<?>> disjuncts = disjunction.getConjunctions();
-			// return disjuncts.size() == 1 && this.equals(disjuncts.get(0));
 			return obj.equals(this);
 		}
 		final Conjunction<?> other = (Conjunction<?>) obj;

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/DisjunctionImpl.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/DisjunctionImpl.java
@@ -1,0 +1,95 @@
+package org.semanticweb.rulewerk.core.model.implementation;
+
+/*-
+ * #%L
+ * Rulewerk Core Components
+ * %%
+ * Copyright (C) 2018 - 2020 Rulewerk Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.Validate;
+import org.semanticweb.rulewerk.core.model.api.Disjunction;
+import org.semanticweb.rulewerk.core.model.api.Conjunction;
+import org.semanticweb.rulewerk.core.model.api.Literal;
+import org.semanticweb.rulewerk.core.model.api.Term;
+
+/**
+ * Simple implementation of {@link Disjunction}.
+ *
+ * @author Lukas Gerlach
+ */
+public class DisjunctionImpl<T extends Conjunction<?>> implements Disjunction<T> {
+
+	final List<? extends T> conjunctions;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param conjunctions a non-null list of conjunctions, that cannot contain null
+	 *                     elements.
+	 */
+	public DisjunctionImpl(List<? extends T> conjunctions) {
+		Validate.noNullElements(conjunctions);
+		this.conjunctions = conjunctions;
+	}
+
+	@Override
+	public List<T> getConjunctions() {
+		return Collections.unmodifiableList(this.conjunctions);
+	}
+
+	@Override
+	public Stream<Term> getTerms() {
+		return this.conjunctions.stream().flatMap(c -> c.getTerms()).distinct();
+	}
+
+	@Override
+	public int hashCode() {
+		return this.conjunctions.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (!(obj instanceof Disjunction<?>)) {
+			return false;
+		}
+		final Disjunction<?> other = (Disjunction<?>) obj;
+		return this.conjunctions.equals(other.getConjunctions());
+	}
+
+	@Override
+	public Iterator<T> iterator() {
+		return getConjunctions().iterator();
+	}
+
+	@Override
+	public String toString() {
+		return Serializer.getSerialization(serializer -> serializer.writeDisjunction(this));
+	}
+
+}

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/DisjunctionImpl.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/DisjunctionImpl.java
@@ -21,7 +21,6 @@ package org.semanticweb.rulewerk.core.model.implementation;
  */
 
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Stream;
 import java.util.stream.Collectors;
@@ -83,11 +82,6 @@ public class DisjunctionImpl<T extends Conjunction<?>> implements Disjunction<T>
 		final Disjunction<?> other = (Disjunction<?>) obj;
 		return this.conjunctions.equals(other.getConjunctions());
 	}
-
-	// @Override
-	// public Iterator<T> iterator() {
-	// 	return getConjunctions().iterator();
-	// }
 
 	@Override
 	public String toString() {

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/DisjunctionImpl.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/DisjunctionImpl.java
@@ -64,7 +64,9 @@ public class DisjunctionImpl<T extends Conjunction<?>> implements Disjunction<T>
 
 	@Override
 	public int hashCode() {
-		return this.conjunctions.hashCode();
+		return this.conjunctions.size() == 1
+			? this.conjunctions.get(0).hashCode()
+			: this.conjunctions.hashCode();
 	}
 
 	@Override
@@ -82,10 +84,10 @@ public class DisjunctionImpl<T extends Conjunction<?>> implements Disjunction<T>
 		return this.conjunctions.equals(other.getConjunctions());
 	}
 
-	@Override
-	public Iterator<T> iterator() {
-		return getConjunctions().iterator();
-	}
+	// @Override
+	// public Iterator<T> iterator() {
+	// 	return getConjunctions().iterator();
+	// }
 
 	@Override
 	public String toString() {

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/Expressions.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/Expressions.java
@@ -304,6 +304,26 @@ public final class Expressions {
 	}
 
 	/**
+	 * Creates a {@link Disjunction} of {@code T} ({@link Conjunction} type) objects.
+	 *
+	 * @param conjunctions list of non-null conjunctions
+	 * @return a {@link Disjunction} corresponding to the input
+	 */
+	public static <T extends Conjunction<?>> Disjunction<T> makeDisjunction(final List<T> conjunctions) {
+		return new DisjunctionImpl<>(conjunctions);
+	}
+
+	/**
+	 * Creates a {@code Disjunction} of {@link Conjunction} objects.
+	 *
+	 * @param conjunctions list of non-null conjunctions
+	 * @return a {@link Disjunction} corresponding to the input
+	 */
+	public static <T extends Conjunction<?>> Disjunction<T> makeDisjunction(final T... conjunctions) {
+		return new DisjunctionImpl<>(Arrays.asList(conjunctions));
+	}
+
+	/**
 	 * Creates a {@code Conjunction} of {@code T} ({@link PositiveLiteral} type)
 	 * objects.
 	 *
@@ -332,19 +352,7 @@ public final class Expressions {
 	 * @return a {@link Rule} corresponding to the input
 	 */
 	public static Rule makeRule(final PositiveLiteral headLiteral, final Literal... bodyLiterals) {
-		return new RuleImpl(new DisjunctionImpl<>(Arrays.asList(new ConjunctionImpl<>(Arrays.asList(headLiteral)))),
-				new ConjunctionImpl<>(Arrays.asList(bodyLiterals)));
-	}
-
-	/**
-	 * Creates a {@code Rule}.
-	 *
-	 * @param head conjunction of positive (non-negated) literals
-	 * @param body conjunction of literals (negated or not)
-	 * @return a {@link Rule} corresponding to the input
-	 */
-	public static Rule makeRule(final Conjunction<PositiveLiteral> head, final Conjunction<Literal> body) {
-		return new RuleImpl(head, body);
+		return new RuleImpl(headLiteral, new ConjunctionImpl<>(Arrays.asList(bodyLiterals)));
 	}
 
 	/**
@@ -354,7 +362,7 @@ public final class Expressions {
 	 * @param body conjunction of literals (negated or not)
 	 * @return a {@link Rule} corresponding to the input
 	 */
-	public static Rule makeRule(final Disjunction<Conjunction<PositiveLiteral>> head, final Conjunction<Literal> body) {
+	public static Rule makeRule(final Disjunction<Conjunction<PositiveLiteral>> head, final Disjunction<Conjunction<Literal>> body) {
 		return new RuleImpl(head, body);
 	}
 

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/Expressions.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/Expressions.java
@@ -9,9 +9,9 @@ package org.semanticweb.rulewerk.core.model.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,6 +26,7 @@ import java.util.List;
 
 import org.semanticweb.rulewerk.core.model.api.AbstractConstant;
 import org.semanticweb.rulewerk.core.model.api.Conjunction;
+import org.semanticweb.rulewerk.core.model.api.Disjunction;
 import org.semanticweb.rulewerk.core.model.api.DatatypeConstant;
 import org.semanticweb.rulewerk.core.model.api.ExistentialVariable;
 import org.semanticweb.rulewerk.core.model.api.Fact;
@@ -43,6 +44,7 @@ import org.semanticweb.rulewerk.core.model.api.UniversalVariable;
  * in Rulewerk.
  *
  * @author Markus Krötzsch
+ * @author Lukas Gerlach
  *
  */
 
@@ -330,7 +332,7 @@ public final class Expressions {
 	 * @return a {@link Rule} corresponding to the input
 	 */
 	public static Rule makeRule(final PositiveLiteral headLiteral, final Literal... bodyLiterals) {
-		return new RuleImpl(new ConjunctionImpl<>(Arrays.asList(headLiteral)),
+		return new RuleImpl(new DisjunctionImpl<>(Arrays.asList(new ConjunctionImpl<>(Arrays.asList(headLiteral)))),
 				new ConjunctionImpl<>(Arrays.asList(bodyLiterals)));
 	}
 
@@ -342,6 +344,17 @@ public final class Expressions {
 	 * @return a {@link Rule} corresponding to the input
 	 */
 	public static Rule makeRule(final Conjunction<PositiveLiteral> head, final Conjunction<Literal> body) {
+		return new RuleImpl(head, body);
+	}
+
+	/**
+	 * Creates a {@code Rule}.
+	 *
+	 * @param head disjunction of conjunctions of positive (non-negated) literals
+	 * @param body conjunction of literals (negated or not)
+	 * @return a {@link Rule} corresponding to the input
+	 */
+	public static Rule makeRule(final Disjunction<Conjunction<PositiveLiteral>> head, final Conjunction<Literal> body) {
 		return new RuleImpl(head, body);
 	}
 

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/Expressions.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/Expressions.java
@@ -305,6 +305,19 @@ public final class Expressions {
 	}
 
 	/**
+	 * Creates a {@link Disjunction} of {@link Conjunction}s of {@code T} ({@link Literal} type) objects.
+	 *
+	 * @param literals list of lists of non-null literals
+	 * @return a {@link Disjunction} corresponding to the input
+	 */
+	public static <T extends Literal> Disjunction<Conjunction<T>> makeDisjunction(final List<List<T>> literals) {
+		final List<Conjunction<T>> disjuncts = literals.stream()
+			.map(c -> makeConjunction(c))
+			.collect(Collectors.toList());
+		return new DisjunctionImpl<>(disjuncts);
+	}
+
+	/**
 	 * Creates a {@code Conjunction} of {@code T} ({@link PositiveLiteral} type)
 	 * objects.
 	 *

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/NegativeLiteralImpl.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/NegativeLiteralImpl.java
@@ -9,9 +9,9 @@ package org.semanticweb.rulewerk.core.model.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,15 +21,20 @@ package org.semanticweb.rulewerk.core.model.implementation;
  */
 
 import java.util.List;
+import java.util.Arrays;
 
 import org.semanticweb.rulewerk.core.model.api.NegativeLiteral;
 import org.semanticweb.rulewerk.core.model.api.Predicate;
 import org.semanticweb.rulewerk.core.model.api.Term;
 
-public class NegativeLiteralImpl extends AbstractLiteralImpl implements NegativeLiteral {
+public class NegativeLiteralImpl extends AbstractLiteralImpl<NegativeLiteral> implements NegativeLiteral {
 
 	public NegativeLiteralImpl(final Predicate predicate, final List<Term> terms) {
 		super(predicate, terms);
 	}
 
+	@Override
+	public List<NegativeLiteral> getLiterals() {
+		return Arrays.asList(this);
+	}
 }

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/NegativeLiteralImpl.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/NegativeLiteralImpl.java
@@ -21,7 +21,6 @@ package org.semanticweb.rulewerk.core.model.implementation;
  */
 
 import java.util.List;
-import java.util.Arrays;
 
 import org.semanticweb.rulewerk.core.model.api.NegativeLiteral;
 import org.semanticweb.rulewerk.core.model.api.Predicate;
@@ -31,10 +30,5 @@ public class NegativeLiteralImpl extends AbstractLiteralImpl<NegativeLiteral> im
 
 	public NegativeLiteralImpl(final Predicate predicate, final List<Term> terms) {
 		super(predicate, terms);
-	}
-
-	@Override
-	public List<NegativeLiteral> getLiterals() {
-		return Arrays.asList(this);
 	}
 }

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/PositiveLiteralImpl.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/PositiveLiteralImpl.java
@@ -21,7 +21,6 @@ package org.semanticweb.rulewerk.core.model.implementation;
  */
 
 import java.util.List;
-import java.util.Arrays;
 
 import org.semanticweb.rulewerk.core.model.api.PositiveLiteral;
 import org.semanticweb.rulewerk.core.model.api.Predicate;
@@ -31,10 +30,5 @@ public class PositiveLiteralImpl extends AbstractLiteralImpl<PositiveLiteral> im
 
 	public PositiveLiteralImpl(final Predicate predicate, final List<Term> terms) {
 		super(predicate, terms);
-	}
-
-	@Override
-	public List<PositiveLiteral> getLiterals() {
-		return Arrays.asList(this);
 	}
 }

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/PositiveLiteralImpl.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/PositiveLiteralImpl.java
@@ -9,9 +9,9 @@ package org.semanticweb.rulewerk.core.model.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,14 +21,20 @@ package org.semanticweb.rulewerk.core.model.implementation;
  */
 
 import java.util.List;
+import java.util.Arrays;
 
 import org.semanticweb.rulewerk.core.model.api.PositiveLiteral;
 import org.semanticweb.rulewerk.core.model.api.Predicate;
 import org.semanticweb.rulewerk.core.model.api.Term;
 
-public class PositiveLiteralImpl extends AbstractLiteralImpl implements PositiveLiteral {
+public class PositiveLiteralImpl extends AbstractLiteralImpl<PositiveLiteral> implements PositiveLiteral {
 
 	public PositiveLiteralImpl(final Predicate predicate, final List<Term> terms) {
 		super(predicate, terms);
+	}
+
+	@Override
+	public List<PositiveLiteral> getLiterals() {
+		return Arrays.asList(this);
 	}
 }

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/RuleImpl.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/RuleImpl.java
@@ -55,9 +55,9 @@ public class RuleImpl implements Rule {
 	 * not occur in the body must be existentially quantified.
 	 *
 	 * @param head list of conjunctions of Literals (negated or non-negated) representing the rule
-	 *             body conjuncts.
-	 * @param body list of positive (non-negated) Literals representing the rule
 	 *             head conjuncts.
+	 * @param body list of conjunctions of positive (non-negated) Literals representing the rule
+	 *             body conjuncts.
 	 */
 	public RuleImpl(final Disjunction<Conjunction<PositiveLiteral>> head, final Disjunction<Conjunction<Literal>> body) {
 		Validate.notNull(head);

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/RuleImpl.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/RuleImpl.java
@@ -1,6 +1,7 @@
 package org.semanticweb.rulewerk.core.model.implementation;
 
 import java.util.Set;
+import java.util.Arrays;
 import java.util.stream.Collectors;
 
 /*-
@@ -12,9 +13,9 @@ import java.util.stream.Collectors;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -27,6 +28,7 @@ import java.util.stream.Stream;
 
 import org.apache.commons.lang3.Validate;
 import org.semanticweb.rulewerk.core.model.api.Conjunction;
+import org.semanticweb.rulewerk.core.model.api.Disjunction;
 import org.semanticweb.rulewerk.core.model.api.Literal;
 import org.semanticweb.rulewerk.core.model.api.PositiveLiteral;
 import org.semanticweb.rulewerk.core.model.api.Rule;
@@ -37,14 +39,15 @@ import org.semanticweb.rulewerk.core.model.api.UniversalVariable;
 /**
  * Implementation for {@link Rule}. Represents rules with non-empty heads and
  * bodies.
- * 
+ *
  * @author Irina Dragoste
+ * @author Lukas Gerlach
  *
  */
 public class RuleImpl implements Rule {
 
 	final Conjunction<Literal> body;
-	final Conjunction<PositiveLiteral> head;
+	final Disjunction<Conjunction<PositiveLiteral>> head;
 
 	/**
 	 * Creates a Rule with a non-empty body and an non-empty head. All variables in
@@ -57,11 +60,28 @@ public class RuleImpl implements Rule {
 	 *             head conjuncts.
 	 */
 	public RuleImpl(final Conjunction<PositiveLiteral> head, final Conjunction<Literal> body) {
+		this(new DisjunctionImpl<>(Arrays.asList(head)), body);
+	}
+
+	/**
+	 * Creates a Rule with a non-empty body and an non-empty head. All variables in
+	 * the body must be universally quantified; all variables in the head that do
+	 * not occur in the body must be existentially quantified.
+	 *
+	 * @param head list of conjunctions of Literals (negated or non-negated) representing the rule
+	 *             body conjuncts.
+	 * @param body list of positive (non-negated) Literals representing the rule
+	 *             head conjuncts.
+	 */
+	public RuleImpl(final Disjunction<Conjunction<PositiveLiteral>> head, final Conjunction<Literal> body) {
 		Validate.notNull(head);
 		Validate.notNull(body);
 		Validate.notEmpty(body.getLiterals(),
 				"Empty rule body not supported. Use Fact objects to assert unconditionally true atoms.");
-		Validate.notEmpty(head.getLiterals(),
+		// Validate.notEmpty(head.getConjunctions(),
+		// 		"Empty rule head not supported. To capture integrity constraints, use a dedicated predicate that represents a contradiction.");
+		// TODO: does this really suffice?
+		Validate.notEmpty(head.getConjunctions().stream().flatMap(c -> c.getLiterals().stream()).collect(Collectors.toList()),
 				"Empty rule head not supported. To capture integrity constraints, use a dedicated predicate that represents a contradiction.");
 		if (body.getExistentialVariables().count() > 0) {
 			throw new IllegalArgumentException(
@@ -109,7 +129,7 @@ public class RuleImpl implements Rule {
 	}
 
 	@Override
-	public Conjunction<PositiveLiteral> getHead() {
+	public Disjunction<Conjunction<PositiveLiteral>> getHead() {
 		return this.head;
 	}
 

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/RuleImpl.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/RuleImpl.java
@@ -46,22 +46,8 @@ import org.semanticweb.rulewerk.core.model.api.UniversalVariable;
  */
 public class RuleImpl implements Rule {
 
-	final Conjunction<Literal> body;
+	final Disjunction<Conjunction<Literal>> body;
 	final Disjunction<Conjunction<PositiveLiteral>> head;
-
-	/**
-	 * Creates a Rule with a non-empty body and an non-empty head. All variables in
-	 * the body must be universally quantified; all variables in the head that do
-	 * not occur in the body must be existentially quantified.
-	 *
-	 * @param head list of Literals (negated or non-negated) representing the rule
-	 *             body conjuncts.
-	 * @param body list of positive (non-negated) Literals representing the rule
-	 *             head conjuncts.
-	 */
-	public RuleImpl(final Conjunction<PositiveLiteral> head, final Conjunction<Literal> body) {
-		this(new DisjunctionImpl<>(Arrays.asList(head)), body);
-	}
 
 	/**
 	 * Creates a Rule with a non-empty body and an non-empty head. All variables in
@@ -73,10 +59,11 @@ public class RuleImpl implements Rule {
 	 * @param body list of positive (non-negated) Literals representing the rule
 	 *             head conjuncts.
 	 */
-	public RuleImpl(final Disjunction<Conjunction<PositiveLiteral>> head, final Conjunction<Literal> body) {
+	public RuleImpl(final Disjunction<Conjunction<PositiveLiteral>> head, final Disjunction<Conjunction<Literal>> body) {
 		Validate.notNull(head);
 		Validate.notNull(body);
-		Validate.notEmpty(body.getLiterals(),
+		// Validate.notEmpty(body.getLiterals(),
+		Validate.notEmpty(body.getConjunctions().stream().flatMap(c -> c.getLiterals().stream()).collect(Collectors.toList()),
 				"Empty rule body not supported. Use Fact objects to assert unconditionally true atoms.");
 		// Validate.notEmpty(head.getConjunctions(),
 		// 		"Empty rule head not supported. To capture integrity constraints, use a dedicated predicate that represents a contradiction.");
@@ -134,7 +121,7 @@ public class RuleImpl implements Rule {
 	}
 
 	@Override
-	public Conjunction<Literal> getBody() {
+	public Disjunction<Conjunction<Literal>> getBody() {
 		return this.body;
 	}
 

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/Serializer.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/Serializer.java
@@ -12,9 +12,9 @@ import java.io.StringWriter;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,6 +35,7 @@ import org.semanticweb.rulewerk.core.model.api.Command;
 import org.semanticweb.rulewerk.core.model.api.Conjunction;
 import org.semanticweb.rulewerk.core.model.api.DataSourceDeclaration;
 import org.semanticweb.rulewerk.core.model.api.DatatypeConstant;
+import org.semanticweb.rulewerk.core.model.api.Disjunction;
 import org.semanticweb.rulewerk.core.model.api.ExistentialVariable;
 import org.semanticweb.rulewerk.core.model.api.Fact;
 import org.semanticweb.rulewerk.core.model.api.LanguageStringConstant;
@@ -52,11 +53,11 @@ import org.semanticweb.rulewerk.core.model.api.UniversalVariable;
 /**
  * Objects of this class are used to create string representations of syntactic
  * objects.
- * 
+ *
  * @see <a href=
  *      "https://github.com/knowsys/rulewerk/wiki/Rule-syntax-grammar">RuleWerk
  *      rule syntax</a>
- * 
+ *
  * @author Markus Kroetzsch
  *
  */
@@ -95,7 +96,7 @@ public class Serializer {
 	/**
 	 * Runtime exception used to report errors that occurred in visitors that do not
 	 * declare checked exceptions.
-	 * 
+	 *
 	 * @author Markus Kroetzsch
 	 *
 	 */
@@ -115,7 +116,7 @@ public class Serializer {
 
 	/**
 	 * Auxiliary class to visit {@link Term} objects for writing.
-	 * 
+	 *
 	 * @author Markus Kroetzsch
 	 *
 	 */
@@ -185,7 +186,7 @@ public class Serializer {
 
 	/**
 	 * Auxiliary class to visit {@link Statement} objects for writing.
-	 * 
+	 *
 	 * @author Markus Kroetzsch
 	 *
 	 */
@@ -225,7 +226,7 @@ public class Serializer {
 
 	/**
 	 * Construct a serializer that uses a specific function to serialize IRIs.
-	 * 
+	 *
 	 * @param writer         the object used to write serializations
 	 * @param iriTransformer a function used to abbreviate IRIs, e.g., if namespace
 	 *                       prefixes were declared
@@ -238,7 +239,7 @@ public class Serializer {
 	/**
 	 * Construct a serializer that serializes IRIs without any form of
 	 * transformation or abbreviation.
-	 * 
+	 *
 	 * @param writer the object used to write serializations
 	 */
 	public Serializer(final Writer writer) {
@@ -248,7 +249,7 @@ public class Serializer {
 	/**
 	 * Construct a serializer that uses the given {@link PrefixDeclarationRegistry}
 	 * to abbreviate IRIs.
-	 * 
+	 *
 	 * @param writer                    the object used to write serializations
 	 * @param prefixDeclarationRegistry the object used to abbreviate IRIs
 	 */
@@ -301,7 +302,7 @@ public class Serializer {
 	 * @throws IOException
 	 */
 	private void writeRuleNoStatment(Rule rule) throws IOException {
-		writeLiteralConjunction(rule.getHead());
+		writeDisjunction(rule.getHead());
 		writer.write(" :- ");
 		writeLiteralConjunction(rule.getBody());
 	}
@@ -374,6 +375,26 @@ public class Serializer {
 				writer.write(", ");
 			}
 			writeLiteral(literal);
+		}
+	}
+
+	/**
+	 * Writes a serialization of the given {@link Disjunction} of {@link Conjunction}
+	 * objects.
+	 *
+	 * @param conjunctions a {@link Disjunction}
+	 * @throws IOException
+	 */
+	public void writeDisjunction(final Disjunction<? extends Conjunction> conjunctions) throws IOException {
+		boolean first = true;
+		for (final Conjunction conjunction : conjunctions.getConjunctions()) {
+			if (first) {
+				first = false;
+			} else {
+				// TODO: think about notation again
+				writer.write("; ");
+			}
+			writeLiteralConjunction(conjunction);
 		}
 	}
 
@@ -550,7 +571,7 @@ public class Serializer {
 
 	/**
 	 * Convenience method for obtaining serializations as Java strings.
-	 * 
+	 *
 	 * @param writeAction a function that accepts a {@link Serializer} and produces
 	 *                    a string
 	 * @return serialization string

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/Serializer.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/Serializer.java
@@ -387,7 +387,7 @@ public class Serializer {
 	 */
 	public void writeDisjunction(final Disjunction<? extends Conjunction> conjunctions) throws IOException {
 		boolean first = true;
-		for (final Conjunction conjunction : conjunctions.getConjunctions()) {
+		for (final Conjunction<?> conjunction : conjunctions.getConjunctions()) {
 			if (first) {
 				first = false;
 			} else {

--- a/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/Serializer.java
+++ b/rulewerk-core/src/main/java/org/semanticweb/rulewerk/core/model/implementation/Serializer.java
@@ -304,7 +304,7 @@ public class Serializer {
 	private void writeRuleNoStatment(Rule rule) throws IOException {
 		writeDisjunction(rule.getHead());
 		writer.write(" :- ");
-		writeLiteralConjunction(rule.getBody());
+		writeDisjunction(rule.getBody());
 	}
 
 	/**
@@ -392,7 +392,7 @@ public class Serializer {
 				first = false;
 			} else {
 				// TODO: think about notation again
-				writer.write("; ");
+				writer.write(" | ");
 			}
 			writeLiteralConjunction(conjunction);
 		}

--- a/rulewerk-parser/src/main/java/org/semanticweb/rulewerk/parser/javacc/JavaCCParser.jj
+++ b/rulewerk-parser/src/main/java/org/semanticweb/rulewerk/parser/javacc/JavaCCParser.jj
@@ -174,7 +174,7 @@ Command command() throws PrefixDeclarationException : {
     | LOOKAHEAD(predicateName() < ARITY >) predicateName = predicateName() arity = < ARITY > < COLON > arguments = Arguments() < DOT > {
 	  		arguments.addFirst(Argument.term(Expressions.makeDatatypeConstant(predicateName + "[" + arity.image + "]:", PrefixDeclarationRegistry.XSD_STRING)));
 	  		return new Command(name.image,arguments);
-	  	}  	
+	  	}
     | arguments = Arguments() < DOT > { return new Command(name.image,arguments); }
 	| pn = < PNAME_NS > arguments = Arguments() < DOT > {
 	  		arguments.addFirst(Argument.term(Expressions.makeDatatypeConstant(pn.image, PrefixDeclarationRegistry.XSD_STRING)));
@@ -204,10 +204,10 @@ Rule rule() throws PrefixDeclarationException : {
 }
 
 Rule ruleNoDot() throws PrefixDeclarationException : {
-    List < PositiveLiteral > head;
-    List < Literal > body;
+    List < List < PositiveLiteral > > head;
+    List < List < Literal > > body;
 } {
-    head = listOfPositiveLiterals(FormulaContext.HEAD) < ARROW > body = listOfLiterals(FormulaContext.BODY) {
+    head = listOfPositiveConjunctions(FormulaContext.HEAD) < ARROW > body = listOfConjunctions(FormulaContext.BODY) {
         // check that the intersection between headExiVars and BodyVars is empty
         for (String variable : headExiVars) {
           if (bodyVars.contains(variable))
@@ -220,8 +220,26 @@ Rule ruleNoDot() throws PrefixDeclarationException : {
             throw new ParseException("Unsafe rule " + head + " :- " + body  + "\nUniversal variable " + variable + " occurs in head but not in body.");
         }
 
-        return Expressions.makeRule(Expressions.makePositiveConjunction(head), Expressions.makeConjunction(body));
+        return Expressions.makeRule(Expressions.makeDisjunction(head), Expressions.makeDisjunction(body));
     }
+}
+
+List < List < PositiveLiteral > > listOfPositiveConjunctions(FormulaContext context) throws PrefixDeclarationException : {
+    List < PositiveLiteral > l;
+    List < List < PositiveLiteral > > list = new ArrayList < List < PositiveLiteral > > ();
+} {
+	l = listOfPositiveLiterals(context) { list.add(l); } ( < LOGICAL_OR > l = listOfPositiveLiterals(context) { list.add(l); } )* {
+		return list;
+	}
+}
+
+List < List < Literal > > listOfConjunctions(FormulaContext context) throws PrefixDeclarationException : {
+    List < Literal > l;
+    List < List < Literal > > list = new ArrayList < List < Literal > > ();
+} {
+	l = listOfLiterals(context) { list.add(l); } ( < LOGICAL_OR > l = listOfLiterals(context) { list.add(l); } )* {
+		return list;
+	}
 }
 
 List < PositiveLiteral > listOfPositiveLiterals(FormulaContext context) throws PrefixDeclarationException : {
@@ -555,6 +573,10 @@ MORE : {
 
 < DEFAULT, BODY, DIRECTIVE_ARGUMENTS > TOKEN : {
   < ARROW : ":-" >
+}
+
+< DEFAULT, BODY > TOKEN : {
+  < LOGICAL_OR : "|" >
 }
 
 < DEFAULT, BODY, DIRECTIVE_ARGUMENTS > TOKEN : {

--- a/rulewerk-parser/src/test/java/org/semanticweb/rulewerk/parser/RuleParserParseFactTest.java
+++ b/rulewerk-parser/src/test/java/org/semanticweb/rulewerk/parser/RuleParserParseFactTest.java
@@ -90,7 +90,7 @@ public class RuleParserParseFactTest implements ParserTestUtils {
 	public void parseRule_namedNullInHead_succeeds() throws ParsingException {
 		String input = "q(_:head) :- p(\"a\") .";
 		Rule result = RuleParser.parseRule(input);
-		Literal literal = result.getHead().getLiterals().get(0);
+		Literal literal = result.getHead().getConjunctions().get(0).getLiterals().get(0);
 		assertArgumentIsNamedNull(literal, 1);
 	}
 }

--- a/rulewerk-vlog/src/main/java/org/semanticweb/rulewerk/reasoner/vlog/ModelToVLogConverter.java
+++ b/rulewerk-vlog/src/main/java/org/semanticweb/rulewerk/reasoner/vlog/ModelToVLogConverter.java
@@ -9,9 +9,9 @@ package org.semanticweb.rulewerk.reasoner.vlog;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,6 +26,7 @@ import java.util.List;
 import org.semanticweb.rulewerk.core.exceptions.RulewerkRuntimeException;
 import org.semanticweb.rulewerk.core.model.api.Conjunction;
 import org.semanticweb.rulewerk.core.model.api.Constant;
+import org.semanticweb.rulewerk.core.model.api.Disjunction;
 import org.semanticweb.rulewerk.core.model.api.Fact;
 import org.semanticweb.rulewerk.core.model.api.Literal;
 import org.semanticweb.rulewerk.core.model.api.NamedNull;
@@ -126,8 +127,17 @@ final class ModelToVLogConverter {
 	}
 
 	static karmaresearch.vlog.Rule toVLogRule(final Rule rule) {
-		final karmaresearch.vlog.Atom[] vLogHead = toVLogAtomArray(rule.getHead());
-		final karmaresearch.vlog.Atom[] vLogBody = toVLogAtomArray(rule.getBody());
+		// TODO: what to do for disjunctions?
+		final Disjunction<?> headDisjunction = rule.getHead();
+		final Disjunction<?> bodyDisjunction = rule.getBody();
+		if (!(headDisjunction instanceof Conjunction<?>) || !(bodyDisjunction instanceof Conjunction<?>)) {
+			throw new IllegalArgumentException("Disjunctions are currently not supported for vlog bindings.");
+		}
+		final Conjunction<?> headConjunction = (Conjunction<?>) headDisjunction;
+		final Conjunction<?> bodyConjunction = (Conjunction<?>) bodyDisjunction;
+
+		final karmaresearch.vlog.Atom[] vLogHead = toVLogAtomArray(headConjunction);
+		final karmaresearch.vlog.Atom[] vLogBody = toVLogAtomArray(bodyConjunction);
 		return new karmaresearch.vlog.Rule(vLogHead, vLogBody);
 	}
 

--- a/rulewerk-vlog/src/main/java/org/semanticweb/rulewerk/reasoner/vlog/ModelToVLogConverter.java
+++ b/rulewerk-vlog/src/main/java/org/semanticweb/rulewerk/reasoner/vlog/ModelToVLogConverter.java
@@ -130,11 +130,11 @@ final class ModelToVLogConverter {
 		// TODO: what to do for disjunctions?
 		final Disjunction<?> headDisjunction = rule.getHead();
 		final Disjunction<?> bodyDisjunction = rule.getBody();
-		if (!(headDisjunction instanceof Conjunction<?>) || !(bodyDisjunction instanceof Conjunction<?>)) {
+		if (headDisjunction.getConjunctions().size() != 1 || bodyDisjunction.getConjunctions().size() != 1) {
 			throw new IllegalArgumentException("Disjunctions are currently not supported for vlog bindings.");
 		}
-		final Conjunction<?> headConjunction = (Conjunction<?>) headDisjunction;
-		final Conjunction<?> bodyConjunction = (Conjunction<?>) bodyDisjunction;
+		final Conjunction<?> headConjunction = headDisjunction.getConjunctions().get(0);
+		final Conjunction<?> bodyConjunction = bodyDisjunction.getConjunctions().get(0);
 
 		final karmaresearch.vlog.Atom[] vLogHead = toVLogAtomArray(headConjunction);
 		final karmaresearch.vlog.Atom[] vLogBody = toVLogAtomArray(bodyConjunction);

--- a/rulewerk-vlog/src/main/java/org/semanticweb/rulewerk/reasoner/vlog/VLogKnowledgeBase.java
+++ b/rulewerk-vlog/src/main/java/org/semanticweb/rulewerk/reasoner/vlog/VLogKnowledgeBase.java
@@ -32,6 +32,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import org.semanticweb.rulewerk.core.exceptions.RulewerkRuntimeException;
+import org.semanticweb.rulewerk.core.model.api.Conjunction;
 import org.semanticweb.rulewerk.core.model.api.DataSource;
 import org.semanticweb.rulewerk.core.model.api.DataSourceDeclaration;
 import org.semanticweb.rulewerk.core.model.api.Fact;
@@ -193,14 +194,16 @@ public class VLogKnowledgeBase {
 		@Override
 		public Void visit(final Rule statement) {
 			VLogKnowledgeBase.this.rules.add(statement);
-			for (final PositiveLiteral positiveLiteral : statement.getHead()) {
-				final Predicate predicate = positiveLiteral.getPredicate();
-				if (!VLogKnowledgeBase.this.idbPredicates.contains(predicate)) {
-					if (VLogKnowledgeBase.this.edbPredicates.containsKey(predicate)) {
-						addEdbAlias(VLogKnowledgeBase.this.edbPredicates.get(predicate));
-						VLogKnowledgeBase.this.edbPredicates.remove(predicate);
+			for (final Conjunction<PositiveLiteral> conjunction : statement.getHead().getConjunctions()) {
+				for (final PositiveLiteral positiveLiteral : conjunction) {
+					final Predicate predicate = positiveLiteral.getPredicate();
+					if (!VLogKnowledgeBase.this.idbPredicates.contains(predicate)) {
+						if (VLogKnowledgeBase.this.edbPredicates.containsKey(predicate)) {
+							addEdbAlias(VLogKnowledgeBase.this.edbPredicates.get(predicate));
+							VLogKnowledgeBase.this.edbPredicates.remove(predicate);
+						}
+						VLogKnowledgeBase.this.idbPredicates.add(predicate);
 					}
-					VLogKnowledgeBase.this.idbPredicates.add(predicate);
 				}
 			}
 			return null;

--- a/rulewerk-vlog/src/main/java/org/semanticweb/rulewerk/reasoner/vlog/VLogReasoner.java
+++ b/rulewerk-vlog/src/main/java/org/semanticweb/rulewerk/reasoner/vlog/VLogReasoner.java
@@ -32,6 +32,7 @@ import org.apache.commons.lang3.Validate;
 import org.semanticweb.rulewerk.core.exceptions.IncompatiblePredicateArityException;
 import org.semanticweb.rulewerk.core.exceptions.ReasonerStateException;
 import org.semanticweb.rulewerk.core.exceptions.RulewerkRuntimeException;
+import org.semanticweb.rulewerk.core.model.api.Conjunction;
 import org.semanticweb.rulewerk.core.model.api.DataSource;
 import org.semanticweb.rulewerk.core.model.api.DataSourceDeclaration;
 import org.semanticweb.rulewerk.core.model.api.Fact;
@@ -429,7 +430,7 @@ public class VLogReasoner implements Reasoner {
 
 	/**
 	 * Utility method copied from {@link karmaresearch.vlog.VLog}.
-	 * 
+	 *
 	 * @FIXME This should be provided by VLog and made visible to us rather than
 	 *        being copied here.
 	 * @param terms
@@ -677,8 +678,10 @@ public class VLogReasoner implements Reasoner {
 	Set<Predicate> getKnowledgeBasePredicates() {
 		final Set<Predicate> toBeQueriedHeadPredicates = new HashSet<>();
 		for (final Rule rule : this.knowledgeBase.getRules()) {
-			for (final Literal literal : rule.getHead()) {
-				toBeQueriedHeadPredicates.add(literal.getPredicate());
+			for (final Conjunction<?> conjunction : rule.getHead().getConjunctions()) {
+				for (final Literal literal : conjunction) {
+					toBeQueriedHeadPredicates.add(literal.getPredicate());
+				}
 			}
 		}
 		for (final DataSourceDeclaration dataSourceDeclaration : this.knowledgeBase.getDataSourceDeclarations()) {


### PR DESCRIPTION
This PR adds support for `Disjunction`s in `Rule` heads and bodies within the `rulewerk-core` package.  
The changes in the other packages were necessary to fit the adjustments in `rulewerk-core`.

To maintain a certain flexibility especially in existing code and also to achieve a pleasant usage of the `Rule` interface, the following basic inheritance structure is introduced:

```
Disjunction <-- Conjunction <-- Literal 
```
In this sense, a `Conjunction` can implicitly be treated as a singleton `Disjunction` and a `Literal` can implicitly be treated as a singleton `Conjunction` (and in turn as a `Disjunction`). A `Rule` then just consists of two `Disjunctions` of `Conjunctions` of `(Positive)Literals`.
The three interfaces also expect generic type arguments to clarify the concrete types of `Conjunctions` and `Literals` especially. Because of that, the structure may seem a bit complicated in the source code but from a usage point of view I guess that this would be convenient.

Note that this is currently still WIP and I'm am going to evaluate how the current implementation suits the needs of an application I'm currently developing using the `rulewerk` library. Also, I still need to implement some tests.
Any kind of feedback is very much appreciated and I'm happy to discuss the design decisions :)