### PR TITLE
use ArrayList instead of HashSet to store rules in VLogKnowledgeBase

### DIFF
--- a/rulewerk-vlog/src/main/java/org/semanticweb/rulewerk/reasoner/vlog/VLogKnowledgeBase.java
+++ b/rulewerk-vlog/src/main/java/org/semanticweb/rulewerk/reasoner/vlog/VLogKnowledgeBase.java
@@ -67,7 +67,7 @@ public class VLogKnowledgeBase {
 
 	private final Map<Predicate, List<Fact>> directEdbFacts = new HashMap<>();
 
-	private final Set<Rule> rules = new HashSet<>();
+	private final List<Rule> rules = new ArrayList<>();
 
 	/**
 	 * Package-protected constructor, that organizes given {@code knowledgeBase} in
@@ -154,7 +154,7 @@ public class VLogKnowledgeBase {
 		return this.directEdbFacts;
 	}
 
-	Set<Rule> getRules() {
+	List<Rule> getRules() {
 		return this.rules;
 	}
 


### PR DESCRIPTION
This pull request aims to maintain rule order in the pre-processing step before passing them to VLog.