### PR TITLE
Allow empty prefix names in declarations and terms

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,6 +1,12 @@
 Rulewerk Release Notes
 ======================
 
+Rulewerk v0.9.0
+---------------
+
+Bugfixes:
+* The parser now accepts empty prefixes, as allowed by, e.g., RDF Turtle. (#206)
+
 Rulewerk v0.8.0
 ---------------
 

--- a/rulewerk-parser/src/main/java/org/semanticweb/rulewerk/parser/javacc/JavaCCParser.jj
+++ b/rulewerk-parser/src/main/java/org/semanticweb/rulewerk/parser/javacc/JavaCCParser.jj
@@ -111,12 +111,19 @@ void base() throws PrefixDeclarationException : {
 	}
 }
 
-void prefix() throws PrefixDeclarationException : {
+String prefixName() : {
 	Token pn;
+} {
+	pn = < COLON > { return pn.image; }
+  | pn = < PNAME_NS > { return pn.image; }
+}
+
+void prefix() throws PrefixDeclarationException : {
+	String pn;
 	String iri;
 } {
-	< PREFIX > pn = < PNAME_NS > iri = absoluteIri() < DOT > {
-		setPrefix(pn.image, iri);
+	< PREFIX > pn = prefixName() iri = absoluteIri() < DOT > {
+		setPrefix(pn, iri);
 	}
 }
 
@@ -174,7 +181,7 @@ Command command() throws PrefixDeclarationException : {
     | LOOKAHEAD(predicateName() < ARITY >) predicateName = predicateName() arity = < ARITY > < COLON > arguments = Arguments() < DOT > {
 	  		arguments.addFirst(Argument.term(Expressions.makeDatatypeConstant(predicateName + "[" + arity.image + "]:", PrefixDeclarationRegistry.XSD_STRING)));
 	  		return new Command(name.image,arguments);
-	  	}  	
+	  	}
     | arguments = Arguments() < DOT > { return new Command(name.image,arguments); }
 	| pn = < PNAME_NS > arguments = Arguments() < DOT > {
 	  		arguments.addFirst(Argument.term(Expressions.makeDatatypeConstant(pn.image, PrefixDeclarationRegistry.XSD_STRING)));

--- a/rulewerk-parser/src/test/java/org/semanticweb/rulewerk/parser/RuleParserTest.java
+++ b/rulewerk-parser/src/test/java/org/semanticweb/rulewerk/parser/RuleParserTest.java
@@ -73,35 +73,35 @@ public class RuleParserTest implements ParserTestUtils {
 	private final Rule rule2 = Expressions.makeRule(this.head, this.body2);
 
 	@Test
-	public void testExplicitIri() throws ParsingException {
+	public void parse_explicitIri_succeeds() throws ParsingException {
 		final String input = "<http://example.org/s>(<http://example.org/c>) .";
 		final ArrayList<Statement> statements = new ArrayList<>(RuleParser.parse(input).getStatements());
 		assertEquals(Arrays.asList(this.fact1), statements);
 	}
 
 	@Test
-	public void testPrefixResolution() throws ParsingException {
+	public void parse_withPrefix_succeeds() throws ParsingException {
 		final String input = "@prefix ex: <http://example.org/> . ex:s(ex:c) .";
 		final ArrayList<Statement> statements = new ArrayList<>(RuleParser.parse(input).getStatements());
 		assertEquals(Arrays.asList(this.fact1), statements);
 	}
 
 	@Test
-	public void testBaseRelativeResolution() throws ParsingException {
+	public void parse_withBaseRelative_succeeds() throws ParsingException {
 		final String input = "@base <http://example.org/> . <s>(<c>) .";
 		final ArrayList<Statement> statements = new ArrayList<>(RuleParser.parse(input).getStatements());
 		assertEquals(Arrays.asList(this.fact1), statements);
 	}
 
 	@Test
-	public void testBaseResolution() throws ParsingException {
+	public void parse_withBase_succeeds() throws ParsingException {
 		final String input = "@base <http://example.org/> . s(c) .";
 		final ArrayList<Statement> statements = new ArrayList<>(RuleParser.parse(input).getStatements());
 		assertEquals(Arrays.asList(this.fact1), statements);
 	}
 
 	@Test
-	public void testNoBaseRelativeIri() throws ParsingException {
+	public void parse_withoutBaseRelative_succeeds() throws ParsingException {
 		final String input = "s(c) .";
 		final ArrayList<Statement> statements = new ArrayList<>(RuleParser.parse(input).getStatements());
 		final PositiveLiteral atom = Expressions.makePositiveLiteral("s", Expressions.makeAbstractConstant("c"));
@@ -109,21 +109,28 @@ public class RuleParserTest implements ParserTestUtils {
 	}
 
 	@Test(expected = ParsingException.class)
-	public void testPrefixConflict() throws ParsingException {
+	public void parse_prefixConflict_throws() throws ParsingException {
 		final String input = "@prefix ex: <http://example.org/> . @prefix ex: <http://example.org/2/> . s(c) .";
 		RuleParser.parse(input);
 	}
 
 	@Test(expected = ParsingException.class)
-	public void testBaseConflict() throws ParsingException {
+	public void parse_baseConflict_throws() throws ParsingException {
 		final String input = "@base <http://example.org/> . @base <http://example.org/2/> . s(c) .";
 		RuleParser.parse(input);
 	}
 
 	@Test(expected = ParsingException.class)
-	public void testMissingPrefix() throws ParsingException {
+	public void parse_undefinedPrefix_throws() throws ParsingException {
 		final String input = "ex:s(c) .";
 		RuleParser.parse(input);
+	}
+
+	@Test
+	public void parse_emptyPrefix_succeeds() throws ParsingException {
+		final String input = "@prefix : <http://example.org/> . :s(:c) .";
+		final ArrayList<Statement> statements = new ArrayList<>(RuleParser.parse(input).getStatements());
+		assertEquals(Arrays.asList(this.fact1), statements);
 	}
 
 	@Test(expected = ParsingException.class)


### PR DESCRIPTION
In accordance with Turtle, allow empty prefix names in prefix declarations and terms. This fixes #206.