### PR TITLE
Owlapi keep all unsupported axioms

### DIFF
--- a/rulewerk-owlapi/src/main/java/org/semanticweb/rulewerk/owlapi/OwlToRulesConverter.java
+++ b/rulewerk-owlapi/src/main/java/org/semanticweb/rulewerk/owlapi/OwlToRulesConverter.java
@@ -44,7 +44,7 @@ public class OwlToRulesConverter {
 	 * The default value for the maximum number of unssuported axioms to be
 	 * registered during the conversion.
 	 */
-	public static final Integer DEFAULT_MAX_UNSUPPORTED_AXIOMS_SIZE = 10;
+	public static final Integer DEFAULT_LIMIT_UNSUPPORTED_AXIOMS_SIZE = 10;
 
 	private static Logger LOGGER = LoggerFactory.getLogger(OwlToRulesConverter.class);
 
@@ -53,7 +53,7 @@ public class OwlToRulesConverter {
 	private final boolean failOnUnsupported;
 	private final List<OWLAxiom> unsupportedAxiomsSample = new ArrayList<>();
 	private int unsupportedAxiomsCount = 0;
-	private Integer maxUnsupportedAxiomsSize = DEFAULT_MAX_UNSUPPORTED_AXIOMS_SIZE;
+	private Integer limitUnsupportedAxiomsSize = DEFAULT_LIMIT_UNSUPPORTED_AXIOMS_SIZE;
 
 	/**
 	 * Constructor.
@@ -94,8 +94,8 @@ public class OwlToRulesConverter {
 				} else {
 					LOGGER.warn(e.getMessage());
 					this.unsupportedAxiomsCount++;
-					if (this.maxUnsupportedAxiomsSize == null
-							|| this.unsupportedAxiomsSample.size() < this.maxUnsupportedAxiomsSize) {
+					if (this.limitUnsupportedAxiomsSize == null
+							|| this.unsupportedAxiomsSample.size() < this.limitUnsupportedAxiomsSize) {
 						this.unsupportedAxiomsSample.add(owlAxiom);
 					}
 				}
@@ -137,11 +137,11 @@ public class OwlToRulesConverter {
 	}
 
 	/**
-	 * Returns up to {@link #getMaxUnsupportedAxiomsSize()} unsupported axioms
-	 * encountered during the conversion. If {@link #getMaxUnsupportedAxiomsSize()}
-	 * is {@code null}, then it returns all unsupported axioms encountered during
-	 * the translation. The complete number of unsupported axioms can be queried
-	 * using {@link #getUnsupportedAxiomsCount()}.
+	 * Returns up to {@link #getLimitUnsupportedAxiomsSize()} unsupported axioms
+	 * encountered during the conversion. If
+	 * {@link #getLimitUnsupportedAxiomsSize()} is {@code null}, then it returns all
+	 * unsupported axioms encountered during the translation. The complete number of
+	 * unsupported axioms can be queried using {@link #getUnsupportedAxiomsCount()}.
 	 * 
 	 * @return list of first ten unsupported axioms that were encountered
 	 */
@@ -152,25 +152,25 @@ public class OwlToRulesConverter {
 	/**
 	 * Sets the maximum number of unsupported axioms to be registered during
 	 * conversion. The default value is 10 (see
-	 * {@link DEFAULT_MAX_UNSUPPORTED_AXIOMS_SIZE}). If set to {@code null}, all
+	 * {@link DEFAULT_LIMIT_UNSUPPORTED_AXIOMS_SIZE}). If set to {@code null}, all
 	 * unsupported axioms encountered during conversion are saved.
 	 * 
 	 * @param maxUnsupportedAxiomsSize
 	 */
-	public void setMaxUnsupportedAxiomsSize(final Integer maxUnsupportedAxiomsSize) {
-		this.maxUnsupportedAxiomsSize = maxUnsupportedAxiomsSize;
+	public void setLimitUnsupportedAxiomsSize(final Integer maxUnsupportedAxiomsSize) {
+		this.limitUnsupportedAxiomsSize = maxUnsupportedAxiomsSize;
 	}
 
 	/**
 	 * Getter for the maximum number of unsupported axioms to be registered during
 	 * conversion. The default value is 10 (see
-	 * {@link DEFAULT_MAX_UNSUPPORTED_AXIOMS_SIZE}). If set to {@code null}, all
+	 * {@link DEFAULT_LIMIT_UNSUPPORTED_AXIOMS_SIZE}). If set to {@code null}, all
 	 * unsupported axioms encountered during conversion are saved.
 	 * 
 	 * @return
 	 */
-	public Integer getMaxUnsupportedAxiomsSize() {
-		return this.maxUnsupportedAxiomsSize;
+	public Integer getLimitUnsupportedAxiomsSize() {
+		return this.limitUnsupportedAxiomsSize;
 	}
 
 }

--- a/rulewerk-owlapi/src/main/java/org/semanticweb/rulewerk/owlapi/OwlToRulesConverter.java
+++ b/rulewerk-owlapi/src/main/java/org/semanticweb/rulewerk/owlapi/OwlToRulesConverter.java
@@ -94,8 +94,8 @@ public class OwlToRulesConverter {
 				} else {
 					LOGGER.warn(e.getMessage());
 					this.unsupportedAxiomsCount++;
-					if (this.maxUnsupportedAxiomsSize != null
-							&& this.unsupportedAxiomsSample.size() <= this.maxUnsupportedAxiomsSize) {
+					if (this.maxUnsupportedAxiomsSize == null
+							|| this.unsupportedAxiomsSample.size() < this.maxUnsupportedAxiomsSize) {
 						this.unsupportedAxiomsSample.add(owlAxiom);
 					}
 				}

--- a/rulewerk-owlapi/src/main/java/org/semanticweb/rulewerk/owlapi/OwlToRulesConverter.java
+++ b/rulewerk-owlapi/src/main/java/org/semanticweb/rulewerk/owlapi/OwlToRulesConverter.java
@@ -51,7 +51,7 @@ public class OwlToRulesConverter {
 	final OwlAxiomToRulesConverter owlAxiomToRulesConverter = new OwlAxiomToRulesConverter();
 
 	private final boolean failOnUnsupported;
-	private final List<OWLAxiom> unsupportedAxiomsSample = new ArrayList<>();
+	private final List<OWLAxiom> unsupportedAxiomsSample = new ArrayList<>(DEFAULT_LIMIT_UNSUPPORTED_AXIOMS_SIZE);
 	private int unsupportedAxiomsCount = 0;
 	private Integer limitUnsupportedAxiomsSize = DEFAULT_LIMIT_UNSUPPORTED_AXIOMS_SIZE;
 

--- a/rulewerk-owlapi/src/test/java/org/semanticweb/rulewerk/owlapi/OwlAxiomToRulesConverterTest.java
+++ b/rulewerk-owlapi/src/test/java/org/semanticweb/rulewerk/owlapi/OwlAxiomToRulesConverterTest.java
@@ -1069,5 +1069,4 @@ public class OwlAxiomToRulesConverterTest {
 			System.out.println(rule);
 		}
 	}
-
 }

--- a/rulewerk-owlapi/src/test/java/org/semanticweb/rulewerk/owlapi/OwlAxiomToRulesConverterTest.java
+++ b/rulewerk-owlapi/src/test/java/org/semanticweb/rulewerk/owlapi/OwlAxiomToRulesConverterTest.java
@@ -679,8 +679,8 @@ public class OwlAxiomToRulesConverterTest {
 	@Test(expected = OwlFeatureNotSupportedException.class)
 	public void testSubClassOfMaxCardinality() {
 
-		OWLClassExpression maxCard = df.getOWLObjectMaxCardinality(1, pR);
-		OWLSubClassOfAxiom axiom = df.getOWLSubClassOfAxiom(cA, maxCard);
+		final OWLClassExpression maxCard = df.getOWLObjectMaxCardinality(1, pR);
+		final OWLSubClassOfAxiom axiom = df.getOWLSubClassOfAxiom(cA, maxCard);
 
 		final OwlAxiomToRulesConverter converter = new OwlAxiomToRulesConverter();
 		axiom.accept(converter);
@@ -974,8 +974,8 @@ public class OwlAxiomToRulesConverterTest {
 	 */
 	@Test
 	public void testNominalsSubClassOfClass() {
-		OWLObjectOneOf oneOfab = df.getOWLObjectOneOf(inda, indb);
-		OWLSubClassOfAxiom axiom = df.getOWLSubClassOfAxiom(oneOfab, cA);
+		final OWLObjectOneOf oneOfab = df.getOWLObjectOneOf(inda, indb);
+		final OWLSubClassOfAxiom axiom = df.getOWLSubClassOfAxiom(oneOfab, cA);
 
 		final OwlAxiomToRulesConverter converter = new OwlAxiomToRulesConverter();
 		axiom.accept(converter);
@@ -993,9 +993,9 @@ public class OwlAxiomToRulesConverterTest {
 	@Test(expected = OwlFeatureNotSupportedException.class)
 	// TODO support this feature
 	public void testNominalsInConjunctionLeftSubClassOfClass() {
-		OWLObjectOneOf oneOfab = df.getOWLObjectOneOf(inda, indb);
-		OWLObjectIntersectionOf conjunction = df.getOWLObjectIntersectionOf(oneOfab, cB);
-		OWLSubClassOfAxiom axiom = df.getOWLSubClassOfAxiom(conjunction, cA);
+		final OWLObjectOneOf oneOfab = df.getOWLObjectOneOf(inda, indb);
+		final OWLObjectIntersectionOf conjunction = df.getOWLObjectIntersectionOf(oneOfab, cB);
+		final OWLSubClassOfAxiom axiom = df.getOWLSubClassOfAxiom(conjunction, cA);
 
 		final OwlAxiomToRulesConverter converter = new OwlAxiomToRulesConverter();
 		axiom.accept(converter);
@@ -1007,9 +1007,9 @@ public class OwlAxiomToRulesConverterTest {
 	@Test(expected = OwlFeatureNotSupportedException.class)
 	// TODO support this feature
 	public void testNominalsInConjunctionRightSubClassOfClass() {
-		OWLObjectOneOf oneOfab = df.getOWLObjectOneOf(inda, indb);
-		OWLObjectIntersectionOf conjunction = df.getOWLObjectIntersectionOf(cB, oneOfab);
-		OWLSubClassOfAxiom axiom = df.getOWLSubClassOfAxiom(conjunction, cA);
+		final OWLObjectOneOf oneOfab = df.getOWLObjectOneOf(inda, indb);
+		final OWLObjectIntersectionOf conjunction = df.getOWLObjectIntersectionOf(cB, oneOfab);
+		final OWLSubClassOfAxiom axiom = df.getOWLSubClassOfAxiom(conjunction, cA);
 
 		final OwlAxiomToRulesConverter converter = new OwlAxiomToRulesConverter();
 		axiom.accept(converter);
@@ -1020,9 +1020,9 @@ public class OwlAxiomToRulesConverterTest {
 	 */
 	@Test(expected = OwlFeatureNotSupportedException.class)
 	public void testClassSubClassOfNominalsInConjunctionRight() {
-		OWLObjectOneOf oneOfab = df.getOWLObjectOneOf(inda, indb);
-		OWLObjectIntersectionOf conjunction = df.getOWLObjectIntersectionOf(cB, oneOfab);
-		OWLSubClassOfAxiom axiom = df.getOWLSubClassOfAxiom(cA, conjunction);
+		final OWLObjectOneOf oneOfab = df.getOWLObjectOneOf(inda, indb);
+		final OWLObjectIntersectionOf conjunction = df.getOWLObjectIntersectionOf(cB, oneOfab);
+		final OWLSubClassOfAxiom axiom = df.getOWLSubClassOfAxiom(cA, conjunction);
 
 		final OwlAxiomToRulesConverter converter = new OwlAxiomToRulesConverter();
 		axiom.accept(converter);
@@ -1033,8 +1033,8 @@ public class OwlAxiomToRulesConverterTest {
 	 */
 	@Test(expected = OwlFeatureNotSupportedException.class)
 	public void testNominalSuperClassOfClass() {
-		OWLObjectOneOf oneOfa = df.getOWLObjectOneOf(inda);
-		OWLSubClassOfAxiom axiom = df.getOWLSubClassOfAxiom(cA, oneOfa);
+		final OWLObjectOneOf oneOfa = df.getOWLObjectOneOf(inda);
+		final OWLSubClassOfAxiom axiom = df.getOWLSubClassOfAxiom(cA, oneOfa);
 
 		final OwlAxiomToRulesConverter converter = new OwlAxiomToRulesConverter();
 		axiom.accept(converter);
@@ -1045,8 +1045,8 @@ public class OwlAxiomToRulesConverterTest {
 	 */
 	@Test(expected = OwlFeatureNotSupportedException.class)
 	public void testNominalsSuperClassOfClass() {
-		OWLObjectOneOf oneOfab = df.getOWLObjectOneOf(inda, indb);
-		OWLSubClassOfAxiom axiom = df.getOWLSubClassOfAxiom(cA, oneOfab);
+		final OWLObjectOneOf oneOfab = df.getOWLObjectOneOf(inda, indb);
+		final OWLSubClassOfAxiom axiom = df.getOWLSubClassOfAxiom(cA, oneOfab);
 
 		final OwlAxiomToRulesConverter converter = new OwlAxiomToRulesConverter();
 		axiom.accept(converter);


### PR DESCRIPTION
Previously, the maximum number of stored unsupported axioms was 10. This feature allows one to set a different limit, including `null` (no limit)